### PR TITLE
fix: ExternalSystemJdkException

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,6 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />


### PR DESCRIPTION
ExternalSystemJdkException: Invalid Gradle JDK configuration found. [qodana-action](https://github.com/burtbai/intellij-plugin-calculator/actions/runs/4619638340/jobs/8168649952)